### PR TITLE
feat: add Samsung-themed login background

### DIFF
--- a/frontend/components/LoginForm.jsx
+++ b/frontend/components/LoginForm.jsx
@@ -108,8 +108,8 @@ export default function LoginForm() {
 		}
 	}
 
-	return (
-		<div className="max-w-sm mx-auto mt-12 bg-white p-8 rounded shadow">
+        return (
+                <div className="w-full max-w-sm bg-white p-8 rounded shadow">
 			<h2 className="text-2xl font-bold mb-6 text-center">Prijava</h2>
 			<form onSubmit={handleSubmit}>
 				<div className="mb-4">

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -2,5 +2,12 @@
 import LoginForm from "../components/LoginForm";
 
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center"
+      style={{ background: "linear-gradient(to right, #1428A0, #000000)" }}
+    >
+      <LoginForm />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- apply Samsung blue-to-black gradient background for login page
- center login form within gradient backdrop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js lint requires configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68c1e30ceae8832faaa9f0289a37458c