### PR TITLE
feat: add Samsung blue login gradient

### DIFF
--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -3,7 +3,7 @@ import LoginForm from "../components/LoginForm";
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-samsung-blue to-black">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-samsung-blue-dark to-samsung-blue-light">
       <LoginForm />
     </div>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,7 +8,9 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'samsung-blue': '#1428A0'
+        'samsung-blue': '#1428A0',
+        'samsung-blue-dark': '#1428A0',
+        'samsung-blue-light': '#1B4FD9'
       }
     }
   },


### PR DESCRIPTION
## Summary
- apply Samsung blue gradient to login page
- add samsung-blue-light and samsung-blue-dark to Tailwind config

## Testing
- `npm --prefix frontend run build` *(fails: NextRouter was not mounted)*
- `npm --prefix frontend run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68c34b3df504832fbb98a2264df8c312