### PR TITLE
feat: add backgrounds for galaxy try and devices

### DIFF
--- a/frontend/pages/devices/index.jsx
+++ b/frontend/pages/devices/index.jsx
@@ -379,7 +379,10 @@ function DevicesPage() {
   const headers = ALL_COLUMNS.filter(c => visible[c.key]);
 
   return (
-    <div className="p-6">
+    <div
+      className="p-6 min-h-screen bg-cover bg-center"
+      style={{ backgroundImage: "url('/Background S25 v1.jpg')" }}
+    >
       <HomeButton />
       <BackBtn />
       <h1 className="text-xl font-bold mb-2">Devices — {code}</h1>

--- a/frontend/pages/galaxy-try/hr/index.jsx
+++ b/frontend/pages/galaxy-try/hr/index.jsx
@@ -135,7 +135,10 @@ function GalaxyTryHRPage() {
   useEffect(() => { load(); }, []);
 
   return (
-    <div className="p-6">
+    <div
+      className="p-6 min-h-screen bg-cover bg-center"
+      style={{ backgroundImage: "url('/Background galaxytry.jpg')" }}
+    >
       {/* Dodano: HomeButton prije glavnog sadržaja/hnaslova */}
       <HomeButton />
 

--- a/frontend/pages/galaxy-try/rs/index.jsx
+++ b/frontend/pages/galaxy-try/rs/index.jsx
@@ -113,7 +113,10 @@ function GalaxyTryRSPage() {
   useEffect(() => { load(); }, []);
 
   return (
-    <div className="p-6">
+    <div
+      className="p-6 min-h-screen bg-cover bg-center"
+      style={{ backgroundImage: "url('/Background galaxytry.jpg')" }}
+    >
       <div className="flex items-center justify-between mb-4">
         <button onClick={() => router.back()} className="px-3 py-2 border rounded hover:bg-gray-50">
           ← Back

--- a/frontend/pages/galaxy-try/si/index.jsx
+++ b/frontend/pages/galaxy-try/si/index.jsx
@@ -113,7 +113,10 @@ function GalaxyTrySIPage() {
   useEffect(() => { load(); }, []);
 
   return (
-    <div className="p-6">
+    <div
+      className="p-6 min-h-screen bg-cover bg-center"
+      style={{ backgroundImage: "url('/Background galaxytry.jpg')" }}
+    >
       <div className="flex items-center justify-between mb-4">
         <button onClick={() => router.back()} className="px-3 py-2 border rounded hover:bg-gray-50">
           ← Back


### PR DESCRIPTION
## Summary
- add background image to Galaxy Try admin pages
- add background image to Devices page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next lint prompts for config)*

------
https://chatgpt.com/codex/tasks/task_b_68c34f806818832f8f9097b6ba7b6aac