### PR TITLE
Add background images to admin pages

### DIFF
--- a/frontend/pages/devices/index.jsx
+++ b/frontend/pages/devices/index.jsx
@@ -44,6 +44,9 @@ function DevicesPage() {
   const [editing, setEditing] = useState(null);   // detail JSON
   const [adding, setAdding] = useState(false);    // bool
 
+  const containerClasses = "p-6 min-h-screen bg-no-repeat bg-cover bg-center";
+  const bgStyle = { backgroundImage: "url('/Background S25 v1.jpg')" };
+
   useEffect(() => {
     let cancelled = false;
     async function load() {
@@ -373,13 +376,13 @@ function DevicesPage() {
     };
   }
 
-  if (loading) return <div className="p-6"><HomeButton /><div>Učitavam…</div></div>;
-  if (err) return <div className="p-6"><HomeButton /><div className="text-red-600">{err}</div></div>;
+  if (loading) return <div className={containerClasses} style={bgStyle}><HomeButton /><div>Učitavam…</div></div>;
+  if (err) return <div className={containerClasses} style={bgStyle}><HomeButton /><div className="text-red-600">{err}</div></div>;
 
   const headers = ALL_COLUMNS.filter(c => visible[c.key]);
 
   return (
-    <div className="p-6">
+    <div className={containerClasses} style={bgStyle}>
       <HomeButton />
       <BackBtn />
       <h1 className="text-xl font-bold mb-2">Devices — {code}</h1>

--- a/frontend/pages/galaxy-try/hr/index.jsx
+++ b/frontend/pages/galaxy-try/hr/index.jsx
@@ -30,6 +30,9 @@ function GalaxyTryHRPage() {
 
   const fileRef = useRef(null);
 
+  const containerClasses = "p-6 min-h-screen bg-no-repeat bg-cover bg-center";
+  const bgStyle = { backgroundImage: "url('/Background galaxytry.jpg')" };
+
   // pomoćne
   function toDateOnly(v) {
     if (!v) return "";
@@ -135,7 +138,7 @@ function GalaxyTryHRPage() {
   useEffect(() => { load(); }, []);
 
   return (
-    <div className="p-6">
+    <div className={containerClasses} style={bgStyle}>
       {/* Dodano: HomeButton prije glavnog sadržaja/hnaslova */}
       <HomeButton />
 

--- a/frontend/pages/galaxy-try/rs/index.jsx
+++ b/frontend/pages/galaxy-try/rs/index.jsx
@@ -29,6 +29,9 @@ function GalaxyTryRSPage() {
 
   const fileRef = useRef(null);
 
+  const containerClasses = "p-6 min-h-screen bg-no-repeat bg-cover bg-center";
+  const bgStyle = { backgroundImage: "url('/Background galaxytry.jpg')" };
+
   // pomoćne
   function toDateOnly(v) {
     if (!v) return "";
@@ -113,7 +116,7 @@ function GalaxyTryRSPage() {
   useEffect(() => { load(); }, []);
 
   return (
-    <div className="p-6">
+    <div className={containerClasses} style={bgStyle}>
       <div className="flex items-center justify-between mb-4">
         <button onClick={() => router.back()} className="px-3 py-2 border rounded hover:bg-gray-50">
           ← Back

--- a/frontend/pages/galaxy-try/si/index.jsx
+++ b/frontend/pages/galaxy-try/si/index.jsx
@@ -29,6 +29,9 @@ function GalaxyTrySIPage() {
 
   const fileRef = useRef(null);
 
+  const containerClasses = "p-6 min-h-screen bg-no-repeat bg-cover bg-center";
+  const bgStyle = { backgroundImage: "url('/Background galaxytry.jpg')" };
+
   // pomoćne
   function toDateOnly(v) {
     if (!v) return "";
@@ -113,7 +116,7 @@ function GalaxyTrySIPage() {
   useEffect(() => { load(); }, []);
 
   return (
-    <div className="p-6">
+    <div className={containerClasses} style={bgStyle}>
       <div className="flex items-center justify-between mb-4">
         <button onClick={() => router.back()} className="px-3 py-2 border rounded hover:bg-gray-50">
           ← Back


### PR DESCRIPTION
## Summary
- apply `Background galaxytry.jpg` to Galaxy Try country pages
- use `Background S25 v1.jpg` as background for Devices page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js ESLint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c34f806818832f8f9097b6ba7b6aac