### PR TITLE
Handle unauthorized Galaxy Try loads

### DIFF
--- a/frontend/lib/auth.js
+++ b/frontend/lib/auth.js
@@ -19,6 +19,19 @@ export function getToken() {
   return sessionStorage.getItem(TOKEN_KEY) || localStorage.getItem(TOKEN_KEY);
 }
 
+// Common handler for unauthorized API responses
+export function handleUnauthorized(router) {
+  if (typeof window === "undefined") return;
+  sessionStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(TOKEN_KEY);
+  alert("Session expired. Please log in again.");
+  if (router?.push) {
+    router.push("/login");
+  } else {
+    window.location.href = "/login";
+  }
+}
+
 export function parseJwt(token) {
   try {
     const base64 = token.split(".")[1];

--- a/frontend/pages/galaxy-try/hr/index.jsx
+++ b/frontend/pages/galaxy-try/hr/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import withAuth from "../../../components/withAuth";
-import { API, getToken } from "../../../lib/auth";
+import { API, getToken, handleUnauthorized } from "../../../lib/auth";
 import CsvImportModal from "../../../components/CsvImportModal";
 import { useRouter } from "next/router";
 import HomeButton from '../../../components/HomeButton';
@@ -122,6 +122,7 @@ function GalaxyTryHRPage() {
       const r = await fetch(`${API}/admin/galaxy-try/hr/list`, {
         headers: { Authorization: `Bearer ${getToken()}` }
       });
+      if (r.status === 401) { handleUnauthorized(router); return; }
       if (!r.ok) throw new Error();
       const data = await r.json();
       setRows((data || []).map(normalizeRow));

--- a/frontend/pages/galaxy-try/rs/index.jsx
+++ b/frontend/pages/galaxy-try/rs/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import withAuth from "../../../components/withAuth";
-import { API, getToken } from "../../../lib/auth";
+import { API, getToken, handleUnauthorized } from "../../../lib/auth";
 import CsvImportModal from "../../../components/CsvImportModal";
 import { useRouter } from "next/router";
 
@@ -100,6 +100,7 @@ function GalaxyTryRSPage() {
       const r = await fetch(`${API}/admin/galaxy-try/rs/list`, {
         headers: { Authorization: `Bearer ${getToken()}` }
       });
+      if (r.status === 401) { handleUnauthorized(router); return; }
       if (!r.ok) throw new Error();
       const data = await r.json();
       setRows((data || []).map(normalizeRow));

--- a/frontend/pages/galaxy-try/si/index.jsx
+++ b/frontend/pages/galaxy-try/si/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import withAuth from "../../../components/withAuth";
-import { API, getToken } from "../../../lib/auth";
+import { API, getToken, handleUnauthorized } from "../../../lib/auth";
 import CsvImportModal from "../../../components/CsvImportModal";
 import { useRouter } from "next/router";
 
@@ -100,6 +100,7 @@ function GalaxyTrySIPage() {
       const r = await fetch(`${API}/admin/galaxy-try/si/list`, {
         headers: { Authorization: `Bearer ${getToken()}` }
       });
+      if (r.status === 401) { handleUnauthorized(router); return; }
       if (!r.ok) throw new Error();
       const data = await r.json();
       setRows((data || []).map(normalizeRow));


### PR DESCRIPTION
## Summary
- centralize unauthorized handling with `handleUnauthorized`
- clear session and redirect to login on 401 responses in Galaxy Try load functions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next lint plugin not installed)


------
https://chatgpt.com/codex/tasks/task_b_68c35d961b98832f931cf6855ded1588