### PR TITLE
Update CSV import aliases for IMEI and lead dates

### DIFF
--- a/frontend/components/CsvImportModal.jsx
+++ b/frontend/components/CsvImportModal.jsx
@@ -20,12 +20,13 @@ const LEAD_FIELDS = [
 const ALIASES = {
   // devices
   "s/n": "serial_number", "sn": "serial_number", "serial": "serial_number",
-  "imei1": "imei", "imei_1": "imei", "imei 1": "imei",
+  "imei": "serial_number", "imei1": "serial_number", "imei_1": "serial_number", "imei 1": "serial_number",
   "control": "control_no", "control no": "control_no", "control_number": "control_no",
   "colour": "color",
   // leads
   "e-mail": "email", "e pošta": "email", "e_posta": "email", "e posta": "email",
   "zip": "postal_code",
+  "created at": "created_at", "handover at": "date_handover",
 };
 
 function guessMap(headers, kind) {
@@ -46,7 +47,6 @@ function guessMap(headers, kind) {
     }
     // special cases
     if (key === "s/n" || key === "s\\n") map[raw] = "serial_number";
-    else if (key === "imei1") map[raw] = "imei";
   });
   return map;
 }


### PR DESCRIPTION
## Summary
- map IMEI and lead date variants in CSV import
- remove special-case IMEI mapping logic

## Testing
- `npx --prefix frontend eslint frontend/components/CsvImportModal.jsx --no-eslintrc --env es2021 --env browser --parser-options '{"ecmaVersion":2021,"sourceType":"module","ecmaFeatures":{"jsx":true}}' -f json`

------
https://chatgpt.com/codex/tasks/task_b_68c407267580832faa3985d3b07bd7ff