### PR TITLE
feat: support csv and excel import in modal

### DIFF
--- a/frontend/components/CsvImportModal.jsx
+++ b/frontend/components/CsvImportModal.jsx
@@ -1,5 +1,5 @@
 // frontend/components/CsvImportModal.jsx
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import Papa from "papaparse";
 import { API, getToken } from "../lib/auth";
 import * as XLSX from "xlsx";
@@ -84,58 +84,8 @@ function toImeiString(v) {
   return String(v).trim().replace(/\s+/g, "");
 }
 
-// === NOVI HANDLER ===
-function handleFile(f) {
-  setFile(f);
-
-  const name = (f.name || "").toLowerCase();
-  const loadCsv = () => new Promise((resolve, reject) => {
-    Papa.parse(f, { header: true, skipEmptyLines: true, complete: resolve, error: reject });
-  });
-
-  (async () => {
-    let data = [];
-    if (name.endsWith(".xlsx") || name.endsWith(".xls")) {
-      const buf = await f.arrayBuffer();
-      const wb = XLSX.read(buf, { cellDates: true });
-      const ws = wb.Sheets[wb.SheetNames[0]];
-      data = XLSX.utils.sheet_to_json(ws, { defval: "" }); // sve vrijednosti, bez undefined
-      const hdrs = data.length ? Object.keys(data[0]) : [];
-      setRows(data);
-      setHeaders(hdrs);
-      setMap(guessMap(hdrs, kind));
-    } else {
-      const res = await loadCsv();
-      const rows = Array.isArray(res.data) ? res.data : [];
-      const hdrs = res.meta?.fields || Object.keys(rows[0] || {});
-      setRows(rows);
-      setHeaders(hdrs);
-      setMap(guessMap(hdrs, kind));
-    }
-  })();
-}
-
-function buildPayload() {
-  return rows.map(r => {
-    const o = {};
-    for (const [src, dst] of Object.entries(map)) {
-      if (!dst) continue;
-      let v = r[src];
-
-      if (kind === "leads") {
-        if (dst === "imei") v = toImeiString(v);
-        else if (dst === "created_at" || dst === "handover_at") v = excelDateToISO(v);
-        else if (dst === "contacted") v = contactedToISO(v);
-        else if (dst === "days_left") v = (v === "" ? null : Number(v));
-      }
-      o[dst] = v ?? null;
-    }
-    return o;
-  });
-}
-
 export default function CsvImportModal({ onClose, countryCode = "HR", kind = "devices" }) {
-  const [file, setFile] = useState(null);
+  const [, setFile] = useState(null);
   const [rows, setRows] = useState([]);
   const [headers, setHeaders] = useState([]);
   const [map, setMap] = useState({});
@@ -145,32 +95,53 @@ export default function CsvImportModal({ onClose, countryCode = "HR", kind = "de
 
   function handleFile(f) {
     setFile(f);
-    Papa.parse(f, {
-      header: true,
-      skipEmptyLines: true,
-      complete: (res) => {
-        const data = Array.isArray(res.data) ? res.data : [];
+
+    const name = (f.name || "").toLowerCase();
+    const loadCsv = () => new Promise((resolve, reject) => {
+      Papa.parse(f, { header: true, skipEmptyLines: true, complete: resolve, error: reject });
+    });
+
+    (async () => {
+      let data = [];
+      if (name.endsWith(".xlsx") || name.endsWith(".xls")) {
+        const buf = await f.arrayBuffer();
+        const wb = XLSX.read(buf, { cellDates: true });
+        const ws = wb.Sheets[wb.SheetNames[0]];
+        data = XLSX.utils.sheet_to_json(ws, { defval: "" });
+        const hdrs = data.length ? Object.keys(data[0]) : [];
         setRows(data);
-        const hdrs = res.meta?.fields || Object.keys(data[0] || {});
+        setHeaders(hdrs);
+        setMap(guessMap(hdrs, kind));
+      } else {
+        const res = await loadCsv();
+        const rows = Array.isArray(res.data) ? res.data : [];
+        const hdrs = res.meta?.fields || Object.keys(rows[0] || {});
+        setRows(rows);
         setHeaders(hdrs);
         setMap(guessMap(hdrs, kind));
       }
-    });
+    })();
   }
 
   const targetFields = kind === "devices" ? DEVICE_FIELDS : LEAD_FIELDS;
 
   function buildPayload() {
-    // premapiraj
-    const out = rows.map(r => {
+    return rows.map(r => {
       const o = {};
       for (const [src, dst] of Object.entries(map)) {
         if (!dst) continue;
-        o[dst] = r[src] ?? null;
+        let v = r[src];
+
+        if (kind === "leads") {
+          if (dst === "imei") v = toImeiString(v);
+          else if (dst === "created_at" || dst === "handover_at") v = excelDateToISO(v);
+          else if (dst === "contacted") v = contactedToISO(v);
+          else if (dst === "days_left") v = (v === "" ? null : Number(v));
+        }
+        o[dst] = v ?? null;
       }
       return o;
     });
-    return out;
   }
 
   async function submit() {


### PR DESCRIPTION
## Summary
- handle CSV and Excel uploads with unified file handler
- normalize lead fields before sending data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c470059640832f86d84f0200df3803