### PR TITLE
Fix contacted checkbox updates in Galaxy Try tables

### DIFF
--- a/frontend/pages/galaxy-try/rs/index.jsx
+++ b/frontend/pages/galaxy-try/rs/index.jsx
@@ -82,7 +82,7 @@ function GalaxyTryRSPage() {
   }
 
   function normalizeRow(r = {}) {
-    const contacted = r.contacted ?? r["Contacted"] ?? !!r.contacted;
+    const contacted = r.contacted ?? r["Contacted"];
     return {
       submission_id: r.submission_id ?? r["Submission ID"] ?? "",
       first_name:     r.first_name     ?? r["First Name"]     ?? "",
@@ -93,12 +93,11 @@ function GalaxyTryRSPage() {
       city:           r.city           ?? r["City"]           ?? "",
       pickup_city:    r.pickup_city    ?? r["Pickup City"]    ?? "",
       created_at:     r.created_at     ?? r["Created At"]     ?? "",
-      contacted: r.contacted ?? "",
-      handover_at:  r.handover_at  ?? r["Handover At"]    ?? "",
+      handover_at:    r.handover_at    ?? r["Handover At"]    ?? "",
       model:          r.model          ?? r["Model"]          ?? "",
-      imei:  r.imei  ?? r["IMEI"]  ?? "",
+      imei:           r.imei           ?? r["IMEI"]           ?? "",
       note:           r.note           ?? r["Note"]           ?? "",
-      contacted: Boolean(contacted),
+      contacted:      Boolean(contacted),
     };
   }
   async function handleDelete(submissionId) {
@@ -138,7 +137,7 @@ function GalaxyTryRSPage() {
       setRows(prev =>
         prev.map(r =>
           r.submission_id === id
-            ? { ...r, contacted: checked, contacted: checked ? new Date().toISOString() : null }
+            ? { ...r, contacted: checked }
             : r
         )
       );

--- a/frontend/pages/galaxy-try/si/index.jsx
+++ b/frontend/pages/galaxy-try/si/index.jsx
@@ -82,7 +82,7 @@ function GalaxyTrySIPage() {
   }
 
   function normalizeRow(r = {}) {
-    const contacted = r.contacted ?? r["Contacted"] ?? !!r.contacted;
+    const contacted = r.contacted ?? r["Contacted"];
     return {
       submission_id: r.submission_id ?? r["Submission ID"] ?? "",
       first_name:     r.first_name     ?? r["First Name"]     ?? "",
@@ -93,12 +93,11 @@ function GalaxyTrySIPage() {
       city:           r.city           ?? r["City"]           ?? "",
       pickup_city:    r.pickup_city    ?? r["Pickup City"]    ?? "",
       created_at:     r.created_at     ?? r["Created At"]     ?? "",
-      contacted: r.contacted ?? "",
-      handover_at:  r.handover_at  ?? r["Handover At"]    ?? "",
+      handover_at:    r.handover_at    ?? r["Handover At"]    ?? "",
       model:          r.model          ?? r["Model"]          ?? "",
-      imei:  r.imei  ?? r["IMEI"]  ?? "",
+      imei:           r.imei           ?? r["IMEI"]           ?? "",
       note:           r.note           ?? r["Note"]           ?? "",
-      contacted: Boolean(contacted),
+      contacted:      Boolean(contacted),
     };
   }
   async function handleDelete(submissionId) {
@@ -138,7 +137,7 @@ function GalaxyTrySIPage() {
       setRows(prev =>
         prev.map(r =>
           r.submission_id === id
-            ? { ...r, contacted: checked, contacted: checked ? new Date().toISOString() : null }
+            ? { ...r, contacted: checked }
             : r
         )
       );


### PR DESCRIPTION
## Summary
- normalize Galaxy Try row data before rendering
- fix contacted checkbox updates so edits persist without losing focus

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68c4752b8324832fb48bb4a07da04b59