### PR TITLE
Remove contacted column checkboxes

### DIFF
--- a/frontend/pages/galaxy-try/hr/index.jsx
+++ b/frontend/pages/galaxy-try/hr/index.jsx
@@ -124,30 +124,6 @@ function GalaxyTryHRPage() {
     }
   }
 
-  async function handleContactedChange(id, checked) {
-    try {
-      const res = await fetch(`${API}/admin/galaxy-try/hr/${encodeURIComponent(id)}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${getToken()}` },
-        body: JSON.stringify({ contacted: checked ? new Date().toISOString() : null }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        alert(data?.error || "Update failed");
-        return;
-      }
-      setRows(prev =>
-        prev.map(r =>
-          r.submission_id === id
-            ? { ...r, contacted: checked }
-            : r
-        )
-      );
-    } catch (err) {
-      console.error('handleContactedChange error', err);
-      alert('Greška pri spremanju kontakta.');
-    }
-  }
 
   async function load() {
     try {
@@ -369,13 +345,7 @@ function GalaxyTryHRPage() {
                       <td>{r.city || "-"}</td>
                       <td>{r.pickup_city ?? "-"}</td>
                       <td>{fmtDateDMY(r.created_at)}</td>
-                      <td className="text-center">
-                        <input
-                          type="checkbox"
-                          checked={r.contacted}
-                          onChange={e => handleContactedChange(r.submission_id, e.target.checked)}
-                        />
-                      </td>
+                      <td className="text-center">{r.contacted ? "Yes" : "No"}</td>
                       <td>{fmtDateDMY(r.handover_at)}</td>
                       <td style={leftStyle}>{left === "" ? "" : left}</td>
                       <td>{r.model ?? "-"}</td>

--- a/frontend/pages/galaxy-try/rs/index.jsx
+++ b/frontend/pages/galaxy-try/rs/index.jsx
@@ -123,30 +123,6 @@ function GalaxyTryRSPage() {
     }
   }
 
-  async function handleContactedChange(id, checked) {
-    try {
-      const res = await fetch(`${API}/admin/galaxy-try/rs/${encodeURIComponent(id)}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${getToken()}` },
-        body: JSON.stringify({ contacted: checked ? new Date().toISOString() : null }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        alert(data?.error || "Update failed");
-        return;
-      }
-      setRows(prev =>
-        prev.map(r =>
-          r.submission_id === id
-            ? { ...r, contacted: checked, contacted: checked ? new Date().toISOString() : null }
-            : r
-        )
-      );
-    } catch (err) {
-      console.error('handleContactedChange error', err);
-      alert('Greška pri spremanju kontakta.');
-    }
-  }
 
   async function load() {
     try {
@@ -368,13 +344,7 @@ function GalaxyTryRSPage() {
                       <td>{r.city || "-"}</td>
                       <td>{r.pickup_city ?? "-"}</td>
                       <td>{fmtDateDMY(r.created_at)}</td>
-                      <td className="text-center">
-                        <input
-                          type="checkbox"
-                          checked={r.contacted}
-                          onChange={e => handleContactedChange(r.submission_id, e.target.checked)}
-                        />
-                      </td>
+                      <td className="text-center">{r.contacted ? "Yes" : "No"}</td>
                       <td>{fmtDateDMY(r.handover_at)}</td>
                       <td style={leftStyle}>{left === "" ? "" : left}</td>
                       <td>{r.model ?? "-"}</td>

--- a/frontend/pages/galaxy-try/si/index.jsx
+++ b/frontend/pages/galaxy-try/si/index.jsx
@@ -123,30 +123,6 @@ function GalaxyTrySIPage() {
     }
   }
 
-  async function handleContactedChange(id, checked) {
-    try {
-      const res = await fetch(`${API}/admin/galaxy-try/si/${encodeURIComponent(id)}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${getToken()}` },
-        body: JSON.stringify({ contacted: checked ? new Date().toISOString() : null }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        alert(data?.error || "Update failed");
-        return;
-      }
-      setRows(prev =>
-        prev.map(r =>
-          r.submission_id === id
-            ? { ...r, contacted: checked, contacted: checked ? new Date().toISOString() : null }
-            : r
-        )
-      );
-    } catch (err) {
-      console.error('handleContactedChange error', err);
-      alert('Greška pri spremanju kontakta.');
-    }
-  }
 
   async function load() {
     try {
@@ -368,13 +344,7 @@ function GalaxyTrySIPage() {
                       <td>{r.city || "-"}</td>
                       <td>{r.pickup_city ?? "-"}</td>
                       <td>{fmtDateDMY(r.created_at)}</td>
-                      <td className="text-center">
-                        <input
-                          type="checkbox"
-                          checked={r.contacted}
-                          onChange={e => handleContactedChange(r.submission_id, e.target.checked)}
-                        />
-                      </td>
+                      <td className="text-center">{r.contacted ? "Yes" : "No"}</td>
                       <td>{fmtDateDMY(r.handover_at)}</td>
                       <td style={leftStyle}>{left === "" ? "" : left}</td>
                       <td>{r.model ?? "-"}</td>


### PR DESCRIPTION
## Summary
- show contacted status as Yes/No instead of checkbox in Galaxy Try lists

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_b_68c473fe43f0832f860fe1366009e729