### PR TITLE
Move created_at column to start of tables

### DIFF
--- a/frontend/pages/galaxy-try/hr/index.jsx
+++ b/frontend/pages/galaxy-try/hr/index.jsx
@@ -235,6 +235,7 @@ function GalaxyTryHRPage() {
   }
 
   const columns = [
+    { key: "created_at", label: "Created At" },
     { key: "first_name", label: "First Name" },
     { key: "last_name", label: "Last Name" },
     { key: "email", label: "Email" },
@@ -242,9 +243,8 @@ function GalaxyTryHRPage() {
     { key: "address", label: "Address" },
     { key: "city", label: "City" },
     { key: "pickup_city", label: "Pickup City" },
-      { key: "created_at", label: "Created At" },
-      { key: "contacted", label: "Contacted Yes/No" },
-      { key: "handover_at", label: "Handover At" },
+    { key: "contacted", label: "Contacted Yes/No" },
+    { key: "handover_at", label: "Handover At" },
     { key: "daysLeft", label: "Days left" },
     { key: "model", label: "Model" },
     { key: "imei", label: "IMEI" },

--- a/frontend/pages/galaxy-try/rs/index.jsx
+++ b/frontend/pages/galaxy-try/rs/index.jsx
@@ -234,6 +234,7 @@ function GalaxyTryRSPage() {
   }
 
   const columns = [
+    { key: "created_at", label: "Created At" },
     { key: "first_name", label: "First Name" },
     { key: "last_name", label: "Last Name" },
     { key: "email", label: "Email" },
@@ -241,9 +242,8 @@ function GalaxyTryRSPage() {
     { key: "address", label: "Address" },
     { key: "city", label: "City" },
     { key: "pickup_city", label: "Pickup City" },
-      { key: "created_at", label: "Created At" },
-      { key: "contacted", label: "Contacted Yes/No" },
-      { key: "handover_at", label: "Handover At" },
+    { key: "contacted", label: "Contacted Yes/No" },
+    { key: "handover_at", label: "Handover At" },
     { key: "daysLeft", label: "Days left" },
     { key: "model", label: "Model" },
     { key: "imei", label: "IMEI" },

--- a/frontend/pages/galaxy-try/si/index.jsx
+++ b/frontend/pages/galaxy-try/si/index.jsx
@@ -234,6 +234,7 @@ function GalaxyTrySIPage() {
   }
 
   const columns = [
+    { key: "created_at", label: "Created At" },
     { key: "first_name", label: "First Name" },
     { key: "last_name", label: "Last Name" },
     { key: "email", label: "Email" },
@@ -241,9 +242,8 @@ function GalaxyTrySIPage() {
     { key: "address", label: "Address" },
     { key: "city", label: "City" },
     { key: "pickup_city", label: "Pickup City" },
-      { key: "created_at", label: "Created At" },
-      { key: "contacted", label: "Contacted Yes/No" },
-      { key: "handover_at", label: "Handover At" },
+    { key: "contacted", label: "Contacted Yes/No" },
+    { key: "handover_at", label: "Handover At" },
     { key: "daysLeft", label: "Days left" },
     { key: "model", label: "Model" },
     { key: "imei", label: "IMEI" },


### PR DESCRIPTION
## Summary
- reorder Galaxy Try admin tables so `created_at` appears before name fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c495f9b9d8832f86426f2d82cfd1f7