### PR TITLE
Organize Try & Buy pages by country

### DIFF
--- a/frontend/pages/dashboard.jsx
+++ b/frontend/pages/dashboard.jsx
@@ -26,24 +26,11 @@ function DashboardPage() {
     return () => { cancelled = true; };
   }, [router.query.code]);
 
-  const gtLink = code ? `/galaxy-try/${code}` : "/galaxy-try";
   const devLink = code ? `/c/${code}/devices` : "/devices";
   const tryBuyLink = "/try-and-buy";
 
   return (
-    <div className="grid grid-cols-3 h-screen bg-gradient-to-br from-samsung-blue to-black">
-      <Link href={gtLink} className="relative block">
-        <div
-          className="absolute inset-0 bg-center bg-cover"
-          style={{ backgroundImage: "url('/Background%20galaxytry.jpg')" }}
-        />
-        <div className="absolute inset-0 bg-black/40" />
-        <div className="relative flex h-full w-full items-center justify-center">
-          <span className="text-white text-4xl md:text-5xl font-bold">
-            GALAXY TRY
-          </span>
-        </div>
-      </Link>
+    <div className="grid grid-cols-2 h-screen bg-gradient-to-br from-samsung-blue to-black">
       <Link href={devLink} className="relative block">
         <div
           className="absolute inset-0 bg-center bg-cover"

--- a/frontend/pages/try-and-buy/index.jsx
+++ b/frontend/pages/try-and-buy/index.jsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { getToken, parseJwt, countryCodeById } from "../../lib/auth";
+
+export default function TryBuyIndex() {
+  const router = useRouter();
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      let target = "hr";
+      try {
+        const t = getToken();
+        const u = t ? parseJwt(t) : null;
+        if (u?.countryId) {
+          const code = await countryCodeById(u.countryId, t);
+          if (code) target = String(code).toLowerCase();
+        }
+      } catch { /* ignore */ }
+      if (!cancelled) router.replace(`/try-and-buy/${target}`);
+    })();
+    return () => { cancelled = true; };
+  }, [router]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Route Try & Buy pages by country code with automatic redirect based on admin location
- Style Try & Buy pages with background, home link, returned & feedback columns, and row colouring by days left
- Streamline dashboard to show only Try & Buy and Devices grids

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c5b200730c832fadbf832314718727