### PR TITLE
Persist Try & Buy data and adjust table layout

### DIFF
--- a/backend/routes/trybuy.js
+++ b/backend/routes/trybuy.js
@@ -1,27 +1,53 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 const router = express.Router();
 
-// In-memory stub storage
-let records = [];
+const DATA_FILE = path.join(__dirname, '..', 'trybuy-data.json');
 
-// GET /api/trybuy - return all records
-router.get('/', (_req, res) => {
+let records = [];
+try {
+  records = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+} catch {
+  records = [];
+}
+
+function save() {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(records, null, 2));
+}
+
+// GET /api/trybuy/:country - return all records (country ignored for now)
+router.get('/:country', (_req, res) => {
   res.json(records);
 });
 
-// PATCH /api/trybuy/:missionId - partial update
-router.patch('/:missionId', (req, res) => {
+// POST /api/trybuy/:country - bulk upsert
+router.post('/:country', (req, res) => {
+  const arr = Array.isArray(req.body) ? req.body : [];
+  arr.forEach((r) => {
+    const idx = records.findIndex((rec) => rec.submission_id === r.submission_id);
+    if (idx === -1) records.push(r);
+    else records[idx] = { ...records[idx], ...r };
+  });
+  save();
+  res.json({ upserted: arr.length });
+});
+
+// PATCH /api/trybuy/:country/:missionId - partial update
+router.patch('/:country/:missionId', (req, res) => {
   const id = String(req.params.missionId);
   const idx = records.findIndex((r) => r.submission_id === id);
   if (idx === -1) return res.status(404).json({ error: 'Not found' });
   records[idx] = { ...records[idx], ...req.body };
+  save();
   res.json(records[idx]);
 });
 
-// DELETE /api/trybuy - bulk delete by missionIds
-router.delete('/', (req, res) => {
+// DELETE /api/trybuy/:country - bulk delete by missionIds
+router.delete('/:country', (req, res) => {
   const ids = Array.isArray(req.body?.missionIds) ? req.body.missionIds.map(String) : [];
   records = records.filter((r) => !ids.includes(r.submission_id));
+  save();
   res.json({ deleted: ids });
 });
 

--- a/frontend/pages/try-and-buy/[code]/index.tsx
+++ b/frontend/pages/try-and-buy/[code]/index.tsx
@@ -117,6 +117,8 @@ function TryAndBuyPage() {
   }, [country]);
 
   const w30 = "w-[30ch]";
+  const w25 = "w-[25ch]";
+  const w22 = "w-[22ch]";
   const w20 = "w-[20ch]";
   const w12 = "w-[12ch]";
   const w10 = "w-[10ch]";
@@ -165,7 +167,7 @@ function TryAndBuyPage() {
       col("last_name", w12),
       col("email", w30, undefined, undefined, true),
       col("phone", w20),
-      col("address", w30),
+      col("address", w25),
       col("city", w10),
       col("postal_code", w6),
       col("pickup_city", w10),
@@ -181,7 +183,7 @@ function TryAndBuyPage() {
       },
       col("model", w12, SelectCell(["", "Fold7", "Watch8"])),
       col("serial", w12),
-      col("note", w12),
+      col("note", w22),
       {
         accessorKey: "returned",
         header: ({ column }) => (
@@ -286,7 +288,13 @@ function TryAndBuyPage() {
             map.set(imp.submission_id, imp);
           }
         });
-        return Array.from(map.values());
+        const merged = Array.from(map.values());
+        fetch(`/api/trybuy/${country}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(merged),
+        }).catch(() => toast.error("Save failed"));
+        return merged;
       });
       toast.success("Import complete");
       e.target.value = "";
@@ -305,6 +313,7 @@ function TryAndBuyPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ missionIds: ids }),
     }).catch(() => toast.error("Delete failed"));
+    setRowSelection({});
   };
 
   return (


### PR DESCRIPTION
## Summary
- Persist Try & Buy records on the backend using a JSON file and add bulk import endpoint
- Save imported data to the backend, clear row selection after delete, and tweak column widths

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68c5c3b80e14832fbd33e008cb31a5c4