### PR TITLE
Fix galaxy try patch returning field

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -363,13 +363,24 @@ app.patch(
            AND country_code  = $${cols.length + 2}
          RETURNING
            submission_id, first_name, last_name, email, phone, address, city, postal_code,
-           pickup_city, created_at, contacted, handover_at, model, serial, note, "return", user_feedback
+           pickup_city, created_at, contacted, handover_at, model, serial, note,
+           returned AS "returned",
+           user_feedback
       `;
 
       const rows = await prisma.$queryRawUnsafe(sql, ...params);
       if (!rows.length) return res.status(404).json({ error: "Not found" });
 
-      return res.json({ ok: true, updated: rows[0] });
+      const rawUpdated = rows[0] || {};
+      const updated = { ...rawUpdated };
+      if (
+        Object.prototype.hasOwnProperty.call(updated, 'returned') &&
+        !Object.prototype.hasOwnProperty.call(updated, 'return')
+      ) {
+        updated.return = updated.returned;
+      }
+
+      return res.json({ ok: true, updated });
     } catch (e) {
       console.error("PATCH galaxy-try error", e);
       return res.status(500).json({ error: "Update failed" });


### PR DESCRIPTION
## Summary
- update the admin galaxy-try PATCH handler to return the renamed `returned` column
- mirror the `returned` value to the legacy `return` key in the JSON payload for compatibility

## Testing
- npm run lint *(fails: `next` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc433b02cc832fbc49550ffa1efe1a