### PR TITLE
Rename returned column to finished and update Galaxy Try UI

### DIFF
--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -8,7 +8,7 @@ router.get("/weekly", (req, res) => {
     country,
     utilizationPct: 0.0,
     avgQueueDaysByModel: [],
-    counts: { applied: 0, issued: 0, returned: 0 }
+    counts: { applied: 0, issued: 0, finished: 0 }
   });
 });
 


### PR DESCRIPTION
## Summary
- replace the returned column with finished in Galaxy Try backend endpoints, including new days_left and country_code projections
- expose finished, days_left, and user feedback data throughout the Galaxy Try HR detail and list screens, updating imports and forms
- align Try & Buy tooling with the finished column for table editing, imports, and API patches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d85ca1f95c832f93e96645f361c021