### PR TITLE
Fix Galaxy Try API errors and improve import feedback

### DIFF
--- a/frontend/pages/galaxy-try/hr/index.jsx
+++ b/frontend/pages/galaxy-try/hr/index.jsx
@@ -700,6 +700,9 @@ async function handleImportGalaxyCsv(e) {
       return o;
     }).filter(x => x.submission_id);
 
+    const totalRows = normalized.length;
+    const skippedRows = totalRows - out.length;
+
     // === DEBUG/PREVIEW & VALIDACIJA ===
     console.log("[GT-HR IMPORT] Preview first 3 mapped rows:", out.slice(0,3));
     const missing = [];
@@ -726,7 +729,10 @@ async function handleImportGalaxyCsv(e) {
     const dataRes = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(dataRes?.error || "Import failed");
 
-    alert(`Import gotov. Upsertano: ${dataRes?.upserted ?? "n/a"}`);
+    const modeLabel = dataRes?.mode || "upsert";
+    const upsertedCount = dataRes?.upserted ?? "n/a";
+    const skippedLabel = skippedRows > 0 ? `, preskočeno: ${skippedRows}` : "";
+    alert(`Import gotov (${modeLabel}). Upsertano: ${upsertedCount}${skippedLabel}`);
   } catch (err) {
     console.error(err);
     alert(`Greška pri importu: ${err.message}`);


### PR DESCRIPTION
## Summary
- add shared Galaxy Try helpers and clean up the CRUD/list/import endpoints to use the leads_import table safely
- support replace mode and better validation in the Galaxy Try import handler and expose a detail route
- surface backend import summaries in the HR/RS/SI Galaxy Try pages so skipped rows and mode are visible

## Testing
- not run (database credentials not available in the container)


------
https://chatgpt.com/codex/tasks/task_b_68d9246dabac832fbc36a3d441a48f6e